### PR TITLE
Add Processes management tab with BPMN viewer

### DIFF
--- a/Home/process/processes/ProcessesForm.tsx
+++ b/Home/process/processes/ProcessesForm.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { Box, Button, Grid, IconButton, TextField } from "@mui/material";
+import { useEffect } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import * as yup from "yup";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+
+export type ProcessItem = {
+  id: number;
+  name: string;
+  coding: string;
+};
+
+type Props = {
+  processes: ProcessItem[];
+  onAdd: (p: Omit<ProcessItem, "id">) => void;
+  onRemove: (id: number) => void;
+  onEdit: (p: ProcessItem) => void;
+};
+
+const schema = yup.object({
+  name: yup.string().required(),
+  coding: yup.string().required(),
+});
+
+const ProcessesForm = ({ processes, onAdd, onRemove, onEdit }: Props) => {
+  const methods = useForm<{ name: string; coding: string }>({
+    resolver: yupResolver(schema),
+  });
+
+  const { handleSubmit, reset } = methods;
+
+  const submit = (data: { name: string; coding: string }) => {
+    onAdd(data);
+    reset();
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <Box component="form" onSubmit={handleSubmit(submit)} sx={{ p: 2 }}>
+        <Grid container spacing={2}>
+          <Grid item xs={12} sm={6}>
+            <TextField label="Name" fullWidth {...methods.register("name")}/>
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField label="Coding" fullWidth {...methods.register("coding")}/>
+          </Grid>
+          <Grid item xs={12}>
+            <Button type="submit" variant="contained">
+              Add
+            </Button>
+          </Grid>
+        </Grid>
+      </Box>
+      <Box sx={{ p: 2 }}>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="px-2">Name</th>
+              <th className="px-2">Coding</th>
+              <th className="px-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {processes.map((p) => (
+              <tr key={p.id} className="odd:bg-gray-100">
+                <td className="px-2">{p.name}</td>
+                <td className="px-2">{p.coding}</td>
+                <td className="px-2">
+                  <IconButton onClick={() => onEdit(p)} size="small">
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton onClick={() => onRemove(p.id)} size="small">
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Box>
+    </FormProvider>
+  );
+};
+
+export default ProcessesForm;

--- a/Home/process/processes/_types/processes.types.ts
+++ b/Home/process/processes/_types/processes.types.ts
@@ -1,5 +1,9 @@
 export type ProcessForm = {
-    name: string,
-    id: number,
-    coding: string
-}
+  name: string;
+  id: number;
+  coding: string;
+};
+
+export type ProcessesState = {
+  list: ProcessForm[];
+};

--- a/Home/process/processes/page.tsx
+++ b/Home/process/processes/page.tsx
@@ -1,18 +1,43 @@
 "use client";
-import MyCustomComponent from "@/app/EndPoints-AsiaApp/Components/Shared/CustomTheme_Mui";
-import React from "react";
+import MyCustomComponent from "@/Shared/CustomTheme_Mui";
+import React, { useState } from "react";
+import ProcessesForm, { ProcessItem } from "./ProcessesForm";
+import BpmnViewer from "@/components/BpmnViewer";
 
-const page = () => {
+const ProcessesPage = () => {
+  const [list, setList] = useState<ProcessItem[]>([]);
+  const [editItem, setEditItem] = useState<ProcessItem | null>(null);
+
+  const addItem = (data: Omit<ProcessItem, "id">) => {
+    setList((prev) => [
+      ...prev,
+      { id: Date.now(), name: data.name, coding: data.coding },
+    ]);
+  };
+
+  const removeItem = (id: number) => {
+    setList((prev) => prev.filter((p) => p.id !== id));
+  };
+
+  const editProcess = (p: ProcessItem) => {
+    setEditItem(p);
+  };
+
   return (
     <div dir="rtl">
       <MyCustomComponent>
-        <div>
-          <h1>test</h1>
-          page
+        <ProcessesForm
+          processes={list}
+          onAdd={addItem}
+          onRemove={removeItem}
+          onEdit={editProcess}
+        />
+        <div className="my-4">
+          <BpmnViewer url="/sample.bpmn" />
         </div>
       </MyCustomComponent>
     </div>
   );
 };
 
-export default page;
+export default ProcessesPage;

--- a/components/BpmnViewer.tsx
+++ b/components/BpmnViewer.tsx
@@ -1,0 +1,28 @@
+"use client";
+import React, { useEffect, useRef } from "react";
+import BpmnJS from "bpmn-js";
+
+const BpmnViewer = ({ url }: { url: string }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const viewer = new BpmnJS({ container: containerRef.current! });
+    let cancelled = false;
+
+    fetch(url)
+      .then((res) => res.text())
+      .then((xml) => {
+        if (cancelled) return;
+        viewer.importXML(xml);
+      });
+
+    return () => {
+      cancelled = true;
+      viewer.destroy();
+    };
+  }, [url]);
+
+  return <div style={{ width: "100%", height: 500 }} ref={containerRef} />;
+};
+
+export default BpmnViewer;

--- a/public/sample.bpmn
+++ b/public/sample.bpmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                   xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                   xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                   id="Definitions_1"
+                   targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1"/>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Summary
- implement `BpmnViewer` component using **bpmn-js**
- add sample BPMN file
- create a basic processes form with React Hook Form and Yup validation
- show table with edit/delete icons
- display BPMN diagram in Processes page

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688875c08f8c8322aee0862ca520cf95